### PR TITLE
Updates deprecated `fp-ts` symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@no-day/fp-ts-graph",
-  "version": "0.2.0",
+  "version": "0.2.1-dev",
   "homepage": "https://github.com/no-day/fp-ts-graph",
   "main": "dist/src/index.js",
   "module": "src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import * as array from 'fp-ts/Array';
 import * as option from 'fp-ts/Option';
 import { Option } from 'fp-ts/Option';
 import * as set_ from 'fp-ts/Set';
-import { Eq, getStructEq } from 'fp-ts/Eq';
+import { Eq, struct } from 'fp-ts/Eq';
 
 // -------------------------------------------------------------------------------------
 // model
@@ -73,8 +73,8 @@ type NodeContext<Id, Node> = {
  */
 export const empty = <Id, Edge, Node>(): Graph<Id, Edge, Node> =>
   unsafeMkGraph({
-    nodes: map_.empty,
-    edges: map_.empty,
+    nodes: new Map(),
+    edges: new Map(),
   });
 
 // -------------------------------------------------------------------------------------
@@ -121,7 +121,7 @@ export const insertNode = <Id>(E: Eq<Id>) => <Node>(id: Id, data: Node) => <
       option.getOrElse(() =>
         pipe(
           graph.nodes,
-          map_.insertAt(E)(id, {
+          map_.upsertAt(E)(id, {
             data,
             incoming: set_.empty as Set<Id>,
             outgoing: set_.empty as Set<Id>,
@@ -146,14 +146,14 @@ export const insertNode = <Id>(E: Eq<Id>) => <Node>(id: Id, data: Node) => <
  *
  *   const myGraph: MyGraph = fp.function.pipe(
  *     graph.empty<string, string, string>(),
- *     graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
- *     graph.insertNode(fp.eq.eqString)('n2', 'Node 2')
+ *     graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+ *     graph.insertNode(fp.string.Eq)('n2', 'Node 2')
  *   );
  *
  *   assert.deepStrictEqual(
  *     fp.function.pipe(
  *       myGraph,
- *       graph.insertEdge(fp.eq.eqString)('n1', 'n2', 'Edge 1'),
+ *       graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1'),
  *       fp.option.map(graph.entries)
  *     ),
  *     fp.option.some({
@@ -420,7 +420,7 @@ export const toDotFile = <Id>(printId: (id: Id) => string) => (
  * @category Instances
  */
 export const getEqEdgeId = <Id>(E: Eq<Id>): Eq<Direction<Id>> =>
-  getStructEq({ from: E, to: E });
+  struct({ from: E, to: E });
 
 // -------------------------------------------------------------------------------------
 // internal
@@ -470,4 +470,4 @@ const insertEdgeInEdges = <Id>(E: Eq<Id>) => <Edge>(
 ) => (
   edges: Graph<Id, Edge, unknown>['edges']
 ): Graph<Id, Edge, unknown>['edges'] =>
-  pipe(edges, map_.insertAt(getEqEdgeId(E))({ from, to }, data));
+  pipe(edges, map_.upsertAt(getEqEdgeId(E))({ from, to }, data));

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -20,8 +20,8 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-            graph.insertNode(fp.eq.eqString)('n2', 'Node 2'),
+            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+            graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
             graph.entries
           ),
           {
@@ -38,8 +38,8 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-            graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
+            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
             graph.entries
           ),
           {
@@ -133,9 +133,9 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-          graph.insertNode(fp.eq.eqString)('n2', 'Node 2'),
-          graph.insertEdge(fp.eq.eqString)('n1', 'n2', 'Edge 1'),
+          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
+          graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1'),
           fp.option.map(graph.entries)
         ),
         fp.option.some({
@@ -152,14 +152,14 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-          graph.insertNode(fp.eq.eqString)('n2', 'Node 2'),
+          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
           fp.option.of,
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n1', 'n2', 'Edge 1')
+            graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
           ),
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n2', 'n1', 'Edge 2')
+            graph.insertEdge(fp.string.Eq)('n2', 'n1', 'Edge 2')
           ),
           fp.option.map(graph.entries)
         ),
@@ -180,8 +180,8 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-          graph.insertEdge(fp.eq.eqString)('n1', 'n1', 'Edge 1'),
+          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+          graph.insertEdge(fp.string.Eq)('n1', 'n1', 'Edge 1'),
           fp.option.map(graph.entries)
         ),
         fp.option.some({
@@ -195,8 +195,8 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-          graph.insertEdge(fp.eq.eqString)('n1', 'n2', 'Edge 1'),
+          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+          graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1'),
           fp.option.map(graph.entries)
         ),
         fp.option.none
@@ -209,12 +209,12 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, number, string>(),
-          graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-          graph.insertNode(fp.eq.eqString)('n2', 'Node 2'),
-          graph.insertNode(fp.eq.eqString)('n3', 'Node 3'),
+          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
+          graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
           fp.option.of,
-          fp.option.chain(graph.insertEdge(fp.eq.eqString)('n1', 'n2', 1)),
-          fp.option.chain(graph.insertEdge(fp.eq.eqString)('n2', 'n3', 2)),
+          fp.option.chain(graph.insertEdge(fp.string.Eq)('n1', 'n2', 1)),
+          fp.option.chain(graph.insertEdge(fp.string.Eq)('n2', 'n3', 2)),
           fp.option.map(graph.mapEdge((n) => `Edge ${n}`)),
           fp.option.map(graph.entries)
         ),
@@ -238,11 +238,11 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, number>(),
-          graph.insertNode(fp.eq.eqString)('n1', 1),
-          graph.insertNode(fp.eq.eqString)('n2', 2),
+          graph.insertNode(fp.string.Eq)('n1', 1),
+          graph.insertNode(fp.string.Eq)('n2', 2),
           fp.option.of,
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n1', 'n2', 'Edge 1')
+            graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
           ),
           fp.option.map(graph.mapNode((n) => `Node ${n}`)),
           fp.option.map(graph.entries)
@@ -263,11 +263,11 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-          graph.insertNode(fp.eq.eqString)('n2', 'Node 2'),
+          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
           fp.option.of,
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n1', 'n2', 'Edge 1')
+            graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
           ),
           fp.option.map(graph.nodeEntries)
         ),
@@ -284,15 +284,15 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-          graph.insertNode(fp.eq.eqString)('n2', 'Node 2'),
-          graph.insertNode(fp.eq.eqString)('n3', 'Node 3'),
+          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
+          graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
           fp.option.of,
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n1', 'n2', 'Edge 1')
+            graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
           ),
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n2', 'n3', 'Edge 2')
+            graph.insertEdge(fp.string.Eq)('n2', 'n3', 'Edge 2')
           ),
           fp.option.map(graph.mapNode((n) => `Node ${n}`)),
           fp.option.map(graph.edgeEntries)
@@ -310,15 +310,15 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-          graph.insertNode(fp.eq.eqString)('n2', 'Node 2'),
-          graph.insertNode(fp.eq.eqString)('n3', 'Node 3'),
+          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
+          graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
           fp.option.of,
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n1', 'n2', 'Edge 1')
+            graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
           ),
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n2', 'n3', 'Edge 2')
+            graph.insertEdge(fp.string.Eq)('n2', 'n3', 'Edge 2')
           ),
           fp.option.map(graph.entries)
         ),
@@ -342,15 +342,15 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.eq.eqString)('n1', 'Node 1'),
-          graph.insertNode(fp.eq.eqString)('n2', 'Node 2'),
-          graph.insertNode(fp.eq.eqString)('n3', 'Node 3'),
+          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
+          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
+          graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
           fp.option.of,
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n1', 'n2', 'Edge 1')
+            graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
           ),
           fp.option.chain(
-            graph.insertEdge(fp.eq.eqString)('n2', 'n3', 'Edge 2')
+            graph.insertEdge(fp.string.Eq)('n2', 'n3', 'Edge 2')
           ),
           fp.option.map(graph.toDotFile(fp.function.identity))
         ),


### PR DESCRIPTION
Updates deprecated `fp-ts` symbols according to suggestions in the documentation:
- `{ getStructEq } from fp-ts/Eq` to `{ struct } from fp-ts/Eq`
- `{ empty } from fp-ts/Map` to `new Map()`
- `{ insertAt } from fp-ts/Map` to `{ upsertAt } from fp-ts/Map`
- `fp.eq.eqString` to `fp.string.Eq`