### PR TITLE
Graph operations performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ import { myGraph } from './build-graph';
 // We import Id codec
 import { MyIdCodec } from './types';
 
-
 pipe(
   myGraph,
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ npm install fp-ts @no-day/fp-ts-graph
 // examples/types.ts
 
 import { Graph } from '@no-day/fp-ts-graph';
+import { Codec } from 'io-ts/Codec';
+import * as Cod from 'io-ts/Codec';
 
 // First, let's define some custom Id, Edge and Node type for our Graph
 
-export type MyId = number;
+export type MyId = string;
 
 export type MyNode = { firstName: string; lastName: string; age: number };
 
@@ -65,17 +67,7 @@ export type MyEdge = { items: number[] };
 
 // Define codec for encoding and decoding Id to string
 
-export const MyIdCodec: Codec<string, string, MyId> = {
-  encode: (a: MyId) => a.toString(),
-  decode: (i: string) =>
-    pipe(
-      Number(i),
-      E.fromPredicate(
-        (parsed: number) => !isNaN(parsed) && i.length > 0,
-        () => Dec.error(i, `${i} is not a number`)
-      )
-    ),
-};
+export const MyIdCodec: Codec<string, string, string> = Cod.string;
 
 // With this we can define a customized Graph type
 
@@ -109,22 +101,22 @@ export const myGraph: Option<MyGraph> = pipe(
   empty,
 
   // And add some nodes to it.
-  insertNode(1001, {
+  insertNode('TC', {
     firstName: 'Tonicha',
     lastName: 'Crowther',
     age: 45,
   }),
-  insertNode(1002, {
+  insertNode('SS', {
     firstName: 'Samual',
     lastName: 'Sierra',
     age: 29,
   }),
-  insertNode(1003, {
+  insertNode('KW', {
     firstName: 'Khushi',
     lastName: 'Walter',
     age: 40,
   }),
-  insertNode(1004, {
+  insertNode('RR', {
     firstName: 'Rian',
     lastName: 'Ruiz',
     age: 56,
@@ -133,10 +125,10 @@ export const myGraph: Option<MyGraph> = pipe(
   // Then we connect them with edges, which can have data, too
 
   O.of,
-  O.chain(insertEdge(1001, 1002, { items: [2, 3] })),
-  O.chain(insertEdge(1002, 1003, { items: [4] })),
-  O.chain(insertEdge(1001, 1003, { items: [9, 4, 3] })),
-  O.chain(insertEdge(1003, 1004, { items: [2, 3] }))
+  O.chain(insertEdge('TC', 'SS', { items: [2, 3] })),
+  O.chain(insertEdge('SS', 'KW', { items: [4] })),
+  O.chain(insertEdge('TC', 'KW', { items: [9, 4, 3] })),
+  O.chain(insertEdge('KW', 'RR', { items: [2, 3] }))
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ export type MyNode = { firstName: string; lastName: string; age: number };
 
 export type MyEdge = { items: number[] };
 
+// Define codec for encoding and decoding Id to string
+
+export const MyIdCodec: Codec<string, string, MyId> = {
+  encode: (a: MyId) => a.toString(),
+  decode: (i: string) =>
+    pipe(
+      Number(i),
+      E.fromPredicate(
+        (parsed: number) => !isNaN(parsed),
+        () => Dec.error(i, `${i} is not a number`)
+      )
+    ),
+};
+
 // With this we can define a customized Graph type
 
 export type MyGraph = Graph<MyId, MyEdge, MyNode>;
@@ -80,13 +94,13 @@ import * as O from 'fp-ts/Option';
 import { Option } from 'fp-ts/Option';
 
 // We import our types from the previous section
-import { MyEdge, MyId, MyNode, MyGraph } from './types';
+import { MyEdge, MyId, MyNode, MyGraph, MyIdCodec } from './types';
 
 // To save some writing, we define partially applied versions of the builder functions
 
 const empty = G.empty<MyId, MyEdge, MyNode>();
-const insertNode = G.insertNode(N.Eq);
-const insertEdge = G.insertEdge(N.Eq);
+const insertNode = G.insertNode(MyIdCodec);
+const insertEdge = G.insertEdge(MyIdCodec);
 
 // Then, let's fill the graph with Data.
 
@@ -138,6 +152,10 @@ import { flow, pipe } from 'fp-ts/function';
 // We import our graph from the previous section
 import { myGraph } from './build-graph';
 
+// We import Id codec
+import { MyIdCodec } from './types';
+
+
 pipe(
   myGraph,
 
@@ -153,7 +171,7 @@ pipe(
       ),
 
       // For debugging, we generate a simple dot file
-      G.toDotFile((_) => _.toString())
+      G.toDotFile(MyIdCodec)((_) => _.toString())
     )
   ),
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fp-ts-graph
 
-Immutable, functional graph data structure for [fp-ts](https://github.com/gcanti/fp-ts).
+Immutable, functional, highly performant graph data structure for [fp-ts](https://github.com/gcanti/fp-ts).
 
 ```ts
 type Graph<Id, Edge, Node> = ...
@@ -71,7 +71,7 @@ export const MyIdCodec: Codec<string, string, MyId> = {
     pipe(
       Number(i),
       E.fromPredicate(
-        (parsed: number) => !isNaN(parsed),
+        (parsed: number) => !isNaN(parsed) && i.length > 0,
         () => Dec.error(i, `${i} is not a number`)
       )
     ),

--- a/examples/build-graph.ts
+++ b/examples/build-graph.ts
@@ -19,22 +19,22 @@ export const myGraph: Option<MyGraph> = pipe(
   empty,
 
   // And add some nodes to it.
-  insertNode(1001, {
+  insertNode('TC', {
     firstName: 'Tonicha',
     lastName: 'Crowther',
     age: 45,
   }),
-  insertNode(1002, {
+  insertNode('SS', {
     firstName: 'Samual',
     lastName: 'Sierra',
     age: 29,
   }),
-  insertNode(1003, {
+  insertNode('KW', {
     firstName: 'Khushi',
     lastName: 'Walter',
     age: 40,
   }),
-  insertNode(1004, {
+  insertNode('RR', {
     firstName: 'Rian',
     lastName: 'Ruiz',
     age: 56,
@@ -43,8 +43,8 @@ export const myGraph: Option<MyGraph> = pipe(
   // Then we connect them with edges, which can have data, too
 
   O.of,
-  O.chain(insertEdge(1001, 1002, { items: [2, 3] })),
-  O.chain(insertEdge(1002, 1003, { items: [4] })),
-  O.chain(insertEdge(1001, 1003, { items: [9, 4, 3] })),
-  O.chain(insertEdge(1003, 1004, { items: [2, 3] }))
+  O.chain(insertEdge('TC', 'SS', { items: [2, 3] })),
+  O.chain(insertEdge('SS', 'KW', { items: [4] })),
+  O.chain(insertEdge('TC', 'KW', { items: [9, 4, 3] })),
+  O.chain(insertEdge('KW', 'RR', { items: [2, 3] }))
 );

--- a/examples/build-graph.ts
+++ b/examples/build-graph.ts
@@ -1,17 +1,16 @@
-import Graph, * as G from '../src';
-import * as N from 'fp-ts/number';
+import * as G from '../src';
 import { pipe } from 'fp-ts/function';
 import * as O from 'fp-ts/Option';
 import { Option } from 'fp-ts/Option';
 
 // We import our types from the previous section
-import { MyEdge, MyId, MyNode, MyGraph } from './types';
+import { MyEdge, MyId, MyNode, MyGraph, MyIdCodec } from './types';
 
 // To save some writing, we define partially applied versions of the builder functions
 
 const empty = G.empty<MyId, MyEdge, MyNode>();
-const insertNode = G.insertNode(N.Eq);
-const insertEdge = G.insertEdge(N.Eq);
+const insertNode = G.insertNode(MyIdCodec);
+const insertEdge = G.insertEdge(MyIdCodec);
 
 // Then, let's fill the graph with Data.
 

--- a/examples/debug-visually.ts
+++ b/examples/debug-visually.ts
@@ -4,6 +4,7 @@ import { flow, pipe } from 'fp-ts/function';
 
 // We import our graph from the previous section
 import { myGraph } from './build-graph';
+import { MyIdCodec } from './types';
 
 pipe(
   myGraph,
@@ -20,7 +21,7 @@ pipe(
       ),
 
       // For debugging, we generate a simple dot file
-      G.toDotFile((_) => _.toString())
+      G.toDotFile(MyIdCodec)((_) => _.toString())
     )
   ),
 

--- a/examples/types.ts
+++ b/examples/types.ts
@@ -1,12 +1,10 @@
 import { Graph } from '../src';
 import { Codec } from 'io-ts/Codec';
-import { pipe } from 'fp-ts/function';
-import * as E from 'fp-ts/Either';
-import * as Dec from 'io-ts/Decoder';
+import * as Cod from 'io-ts/Codec';
 
 // First, let's define some custom Id, Edge and Node type for our Graph
 
-export type MyId = number;
+export type MyId = string;
 
 export type MyNode = { firstName: string; lastName: string; age: number };
 
@@ -16,14 +14,4 @@ export type MyEdge = { items: number[] };
 
 export type MyGraph = Graph<MyId, MyEdge, MyNode>;
 
-export const MyIdCodec: Codec<string, string, MyId> = {
-  encode: (a: MyId) => a.toString(),
-  decode: (i: string) =>
-    pipe(
-      Number(i),
-      E.fromPredicate(
-        (parsed: number) => !isNaN(parsed) && i.length > 0,
-        () => Dec.error(i, `${i} is not a number`)
-      )
-    ),
-};
+export const MyIdCodec: Codec<string, string, string> = Cod.string;

--- a/examples/types.ts
+++ b/examples/types.ts
@@ -1,4 +1,8 @@
 import { Graph } from '../src';
+import { Codec } from 'io-ts/Codec';
+import { pipe } from 'fp-ts/function';
+import * as E from 'fp-ts/Either';
+import * as Dec from 'io-ts/Decoder';
 
 // First, let's define some custom Id, Edge and Node type for our Graph
 
@@ -11,3 +15,15 @@ export type MyEdge = { items: number[] };
 // With this we can define a customized Graph type
 
 export type MyGraph = Graph<MyId, MyEdge, MyNode>;
+
+export const MyIdCodec: Codec<string, string, MyId> = {
+  encode: (a: MyId) => a.toString(),
+  decode: (i: string) =>
+    pipe(
+      Number(i),
+      E.fromPredicate(
+        (parsed: number) => !isNaN(parsed),
+        () => Dec.error(i, `${i} is not a number`)
+      )
+    ),
+};

--- a/examples/types.ts
+++ b/examples/types.ts
@@ -22,7 +22,7 @@ export const MyIdCodec: Codec<string, string, MyId> = {
     pipe(
       Number(i),
       E.fromPredicate(
-        (parsed: number) => !isNaN(parsed),
+        (parsed: number) => !isNaN(parsed) && i.length > 0,
         () => Dec.error(i, `${i} is not a number`)
       )
     ),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@no-day/fp-ts-graph",
-  "version": "0.2.2",
+  "version": "0.3.0-dev",
   "homepage": "https://github.com/no-day/fp-ts-graph",
   "main": "dist/src/index.js",
   "module": "src/index.ts",
@@ -17,6 +17,7 @@
     "docs-ts": "^0.6.10",
     "doctoc": "^2.0.1",
     "fp-ts": "^2.11.1",
+    "io-ts": "^2.2.16",
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "prettier-plugin-jsdoc": "^0.3.23",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "docs-ts": "^0.6.10",
     "doctoc": "^2.0.1",
     "fp-ts": "^2.11.1",
-    "io-ts": "^2.2.16",
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "prettier-plugin-jsdoc": "^0.3.23",
@@ -34,5 +33,8 @@
     "pretty": "yarn run prettier --check .",
     "doctoc": "yarn doctoc"
   },
-  "dependencies": {}
+  "dependencies": {
+    "io-ts": "^2.2.16",
+    "immutable": "^4.0.0-rc.14"
+  }
 }

--- a/src/ImmutableMap.ts
+++ b/src/ImmutableMap.ts
@@ -1,7 +1,8 @@
 /** @since 0.3.0 */
 
+import { Option } from 'fp-ts/Option';
 import * as O from 'fp-ts/Option';
-import * as Enc from 'io-ts/Encoder';
+import { Encoder } from 'io-ts/Encoder';
 import { Map } from 'immutable';
 import { pipe } from 'fp-ts/function';
 
@@ -12,7 +13,7 @@ import { pipe } from 'fp-ts/function';
  * @category Combinators
  */
 export const upsertAt =
-  <K>(E: Enc.Encoder<string, K>) =>
+  <K>(E: Encoder<string, K>) =>
   <A>(k: K, a: A) =>
   (m: Map<string, A>): Map<string, A> => {
     const encodedKey = E.encode(k);
@@ -29,9 +30,9 @@ export const upsertAt =
  * @category Combinators
  */
 export const modifyAt =
-  <K>(E: Enc.Encoder<string, K>) =>
+  <K>(E: Encoder<string, K>) =>
   <A>(k: K, f: (a: A) => A) =>
-  (m: Map<string, A>): O.Option<Map<string, A>> => {
+  (m: Map<string, A>): Option<Map<string, A>> => {
     const encodedKey = E.encode(k);
     return pipe(
       m.get(encodedKey, null),
@@ -47,7 +48,7 @@ export const modifyAt =
  * @category Utils
  */
 export const lookup =
-  <K>(E: Enc.Encoder<string, K>) =>
+  <K>(E: Encoder<string, K>) =>
   (k: K) =>
-  <A>(m: Map<string, A>): O.Option<A> =>
+  <A>(m: Map<string, A>): Option<A> =>
     pipe(m.get(E.encode(k), null), O.fromNullable);

--- a/src/ImmutableMap.ts
+++ b/src/ImmutableMap.ts
@@ -1,0 +1,53 @@
+/** @since 0.3.0 */
+
+import * as O from 'fp-ts/Option';
+import * as Enc from 'io-ts/Encoder';
+import { Map } from 'immutable';
+import { pipe } from 'fp-ts/function';
+
+/**
+ * Insert or replace a key/value pair in an immutable `Map`.
+ *
+ * @since 0.3.0
+ * @category Combinators
+ */
+export const upsertAt =
+  <K>(E: Enc.Encoder<string, K>) =>
+  <A>(k: K, a: A) =>
+  (m: Map<string, A>): Map<string, A> => {
+    const encodedKey = E.encode(k);
+    if (m.has(encodedKey) && m.get(encodedKey) === a) {
+      return m;
+    }
+    return m.set(encodedKey, a);
+  };
+
+/**
+ * Update a key/value pair in an immutable `Map`.
+ *
+ * @since 0.3.0
+ * @category Combinators
+ */
+export const modifyAt =
+  <K>(E: Enc.Encoder<string, K>) =>
+  <A>(k: K, f: (a: A) => A) =>
+  (m: Map<string, A>): O.Option<Map<string, A>> => {
+    const encodedKey = E.encode(k);
+    return pipe(
+      m.get(encodedKey, null),
+      O.fromNullable,
+      O.map((value) => m.set(encodedKey, f(value)))
+    );
+  };
+
+/**
+ * Lookup the value for a key in an immutable `Map`.
+ *
+ * @since 0.3.0
+ * @category Utils
+ */
+export const lookup =
+  <K>(E: Enc.Encoder<string, K>) =>
+  (k: K) =>
+  <A>(m: Map<string, A>): O.Option<A> =>
+    pipe(m.get(E.encode(k), null), O.fromNullable);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,10 @@ import { pipe } from 'fp-ts/function';
 import * as A from 'fp-ts/Array';
 import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
-import * as Cod from 'io-ts/Codec';
-import * as Dec from 'io-ts/Decoder';
-import * as Enc from 'io-ts/Encoder';
+import { Option } from 'fp-ts/Option';
+import { Codec } from 'io-ts/Codec';
+import { Decoder } from 'io-ts/Decoder';
+import { Encoder } from 'io-ts/Encoder';
 import { Map, Set } from 'immutable';
 import * as IM from './ImmutableMap';
 
@@ -112,7 +113,7 @@ export const empty = <Id, Edge, Node>(): Graph<Id, Edge, Node> =>
  *   assert.deepStrictEqual(pipe(myGraph, G.edgeEntries(C.string)), []);
  */
 export const insertNode =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   <Node>(id: Id, data: Node) =>
   <Edge>(graph: Graph<Id, Edge, Node>): Graph<Id, Edge, Node> =>
     unsafeMkGraph({
@@ -173,9 +174,9 @@ export const insertNode =
  *   );
  */
 export const insertEdge =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   <Edge>(from: Id, to: Id, data: Edge) =>
-  <Node>(graph: Graph<Id, Edge, Node>): O.Option<Graph<Id, Edge, Node>> =>
+  <Node>(graph: Graph<Id, Edge, Node>): Option<Graph<Id, Edge, Node>> =>
     pipe(
       graph.nodes,
       modifyEdgeInNodes(E)(from, to),
@@ -236,9 +237,9 @@ export const map = mapNode;
  * @category Combinators
  */
 export const modifyAtEdge =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   <Edge>(from: Id, to: Id, update: (e: Edge) => Edge) =>
-  <Node>(graph: Graph<Id, Edge, Node>): O.Option<Graph<Id, Edge, Node>> =>
+  <Node>(graph: Graph<Id, Edge, Node>): Option<Graph<Id, Edge, Node>> =>
     pipe(
       graph.edges,
       IM.lookup(E)(from),
@@ -259,9 +260,9 @@ export const modifyAtEdge =
  * @category Combinators
  */
 export const modifyAtNode =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   <Node>(id: Id, update: (n: Node) => Node) =>
-  <Edge>(graph: Graph<Id, Edge, Node>): O.Option<Graph<Id, Edge, Node>> =>
+  <Edge>(graph: Graph<Id, Edge, Node>): Option<Graph<Id, Edge, Node>> =>
     pipe(
       graph.nodes,
       IM.modifyAt(E)(id, ({ incoming, outgoing, data }) => ({
@@ -304,9 +305,9 @@ export const modifyAtNode =
  *   );
  */
 export const lookupEdge =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   (from: Id, to: Id) =>
-  <Edge>(graph: Graph<Id, Edge, unknown>): O.Option<Edge> =>
+  <Edge>(graph: Graph<Id, Edge, unknown>): Option<Edge> =>
     pipe(graph.edges, IM.lookup(E)(from), O.chain(IM.lookup(E)(to)));
 
 /**
@@ -334,9 +335,9 @@ export const lookupEdge =
  *   );
  */
 export const lookupNode =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   (id: Id) =>
-  <Node>(graph: Graph<Id, unknown, Node>): O.Option<Node> =>
+  <Node>(graph: Graph<Id, unknown, Node>): Option<Node> =>
     pipe(
       graph.nodes,
       IM.lookup(E)(id),
@@ -354,7 +355,7 @@ export const lookupNode =
  * @category Destructors
  */
 export const nodeEntries =
-  <Id>(D: Dec.Decoder<string, Id>) =>
+  <Id>(D: Decoder<string, Id>) =>
   <Edge, Node>(graph: Graph<Id, Edge, Node>): [Id, Node][] =>
     pipe(
       graph.nodes.map((_) => _.data),
@@ -369,7 +370,7 @@ export const nodeEntries =
  * @category Destructors
  */
 export const edgeEntries =
-  <Id>(D: Dec.Decoder<string, Id>) =>
+  <Id>(D: Decoder<string, Id>) =>
   <Edge, Node>(graph: Graph<Id, Edge, Node>): [Direction<Id>, Edge][] =>
     pipe(
       graph.edges.toArray(),
@@ -394,7 +395,7 @@ export const edgeEntries =
  * @category Destructors
  */
 export const entries =
-  <Id>(C: Cod.Codec<string, string, Id>) =>
+  <Id>(C: Codec<string, string, Id>) =>
   <Edge, Node>(
     graph: Graph<Id, Edge, Node>
   ): { nodes: [Id, Node][]; edges: [Direction<Id>, Edge][] } => ({
@@ -420,7 +421,7 @@ export const entries =
  * @category Debug
  */
 export const toDotFile =
-  <Id>(D: Dec.Decoder<string, Id>) =>
+  <Id>(D: Decoder<string, Id>) =>
   (printId: (id: Id) => string) =>
   (graph: Graph<Id, string, string>): string =>
     pipe(
@@ -450,7 +451,7 @@ const unsafeMkGraph = <Id, Edge, Node>(
 ): Graph<Id, Edge, Node> => graphData as Graph<Id, Edge, Node>;
 
 const mapEntries =
-  <Id>(decoder: Dec.Decoder<string, Id>) =>
+  <Id>(decoder: Decoder<string, Id>) =>
   <V>(map_: Map<string, V>): [Id, V][] =>
     pipe(
       map_.toArray(),
@@ -465,7 +466,7 @@ const mapEntries =
     );
 
 const insertIncoming =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   (from: Id) =>
   <Node>(nodeContext: NodeContext<Node>): NodeContext<Node> => ({
     data: nodeContext.data,
@@ -474,7 +475,7 @@ const insertIncoming =
   });
 
 const insertOutgoing =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   (from: Id) =>
   <Node>(nodeContext: NodeContext<Node>): NodeContext<Node> => ({
     data: nodeContext.data,
@@ -483,11 +484,11 @@ const insertOutgoing =
   });
 
 const modifyEdgeInNodes =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   (from: Id, to: Id) =>
   <Node>(
     nodes: Graph<Id, unknown, Node>['nodes']
-  ): O.Option<Graph<Id, unknown, Node>['nodes']> =>
+  ): Option<Graph<Id, unknown, Node>['nodes']> =>
     pipe(
       nodes,
       IM.modifyAt(E)(from, insertOutgoing(E)(to)),
@@ -495,7 +496,7 @@ const modifyEdgeInNodes =
     );
 
 const insertEdgeInEdges =
-  <Id>(E: Enc.Encoder<string, Id>) =>
+  <Id>(E: Encoder<string, Id>) =>
   <Edge>(from: Id, to: Id, data: Edge) =>
   (
     edges: Graph<Id, Edge, unknown>['edges']

--- a/tests/ImmutableMap.ts
+++ b/tests/ImmutableMap.ts
@@ -1,0 +1,79 @@
+import { Map } from 'immutable';
+import { pipe } from 'fp-ts/function';
+import * as O from 'fp-ts/Option';
+import * as C from 'io-ts/Codec';
+import * as IM from '../src/ImmutableMap';
+
+describe('ImmutableMap', () => {
+  describe('upsertAt', () => {
+    test('Should insert two records in a map', () => {
+      expect(
+        pipe(
+          Map<string, string>(),
+          IM.upsertAt(C.string)('hello', 'world'),
+          IM.upsertAt(C.string)('foo', 'bar')
+        )
+      ).toStrictEqual(
+        Map(<[string, string][]>[
+          ['hello', 'world'],
+          ['foo', 'bar'],
+        ])
+      );
+    });
+  });
+
+  describe('modifyAt', () => {
+    test('Should update record in a map', () => {
+      expect(
+        pipe(
+          Map<string, string>(),
+          IM.upsertAt(C.string)('hello', 'world'),
+          IM.upsertAt(C.string)('foo', 'bar'),
+          IM.modifyAt(C.string)('hello', () => 'yellow')
+        )
+      ).toStrictEqual(
+        O.some(
+          Map(<[string, string][]>[
+            ['hello', 'yellow'],
+            ['foo', 'bar'],
+          ])
+        )
+      );
+    });
+
+    test('Should fail updating missing record in a map', () => {
+      expect(
+        pipe(
+          Map<string, string>(),
+          IM.upsertAt(C.string)('hello', 'world'),
+          IM.upsertAt(C.string)('foo', 'bar'),
+          IM.modifyAt(C.string)('world', () => 'hello')
+        )
+      ).toStrictEqual(O.none);
+    });
+  });
+
+  describe('lookup', () => {
+    test('Should lookup existing record in a map', () => {
+      expect(
+        pipe(
+          Map<string, string>(),
+          IM.upsertAt(C.string)('hello', 'world'),
+          IM.upsertAt(C.string)('foo', 'bar'),
+          IM.lookup(C.string)('foo')
+        )
+      ).toStrictEqual(O.some('bar'));
+    });
+
+    test('Should fail when looking up missing record in a map', () => {
+      expect(
+        pipe(
+          Map<string, string>(),
+          IM.upsertAt(C.string)('hello', 'world'),
+          IM.upsertAt(C.string)('foo', 'bar'),
+          IM.lookup(C.string)('bar')
+        )
+      ).toStrictEqual(O.none);
+    });
+  });
+});

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,15 +1,22 @@
 import * as graph from '../src';
 import { deepStrictEqual } from 'assert';
 import * as fp from 'fp-ts';
+import * as Codec from 'io-ts/Codec';
 
 describe('index', () => {
   describe('Constructors', () => {
     describe('empty', () => {
       it('should return an empty graph', () => {
-        deepStrictEqual(fp.function.pipe(graph.empty(), graph.entries), {
-          nodes: [],
-          edges: [],
-        });
+        deepStrictEqual(
+          fp.function.pipe(
+            graph.empty<string, string, string>(),
+            graph.entries(Codec.string)
+          ),
+          {
+            nodes: [],
+            edges: [],
+          }
+        );
       });
     });
   });
@@ -20,9 +27,9 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-            graph.entries
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.insertNode(Codec.string)('n2', 'Node 2'),
+            graph.entries(Codec.string)
           ),
           {
             nodes: [
@@ -38,9 +45,9 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.entries
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.entries(Codec.string)
           ),
           {
             nodes: [['n1', 'Node 1']],
@@ -55,20 +62,20 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.insertNode(Codec.string)('n2', 'Node 2'),
             fp.option.of,
             fp.option.chain(
-              graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
+              graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')
             ),
             fp.option.chain(
-              graph.modifyAtEdge(fp.string.Eq)(
+              graph.modifyAtEdge(Codec.string)(
                 'n1',
                 'n2',
                 (e) => `${e} updated`
               )
             ),
-            fp.option.map(graph.edgeEntries)
+            fp.option.map(graph.edgeEntries(Codec.string))
           ),
           fp.option.some([[{ from: 'n1', to: 'n2' }, 'Edge 1 updated']])
         );
@@ -78,20 +85,20 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.insertNode(Codec.string)('n2', 'Node 2'),
             fp.option.of,
             fp.option.chain(
-              graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
+              graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')
             ),
             fp.option.chain(
-              graph.modifyAtEdge(fp.string.Eq)(
+              graph.modifyAtEdge(Codec.string)(
                 'n2',
                 'n1',
                 (e) => `${e} updated`
               )
             ),
-            fp.option.map(graph.edgeEntries)
+            fp.option.map(graph.edgeEntries(Codec.string))
           ),
           fp.option.none
         );
@@ -103,10 +110,10 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-            graph.modifyAtNode(fp.string.Eq)('n2', (n) => `${n} updated`),
-            fp.option.map(graph.nodeEntries)
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.insertNode(Codec.string)('n2', 'Node 2'),
+            graph.modifyAtNode(Codec.string)('n2', (n) => `${n} updated`),
+            fp.option.map(graph.nodeEntries(Codec.string))
           ),
           fp.option.some([
             ['n1', 'Node 1'],
@@ -119,10 +126,10 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-            graph.modifyAtNode(fp.string.Eq)('n3', (n) => `${n} updated`),
-            fp.option.map(graph.nodeEntries)
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.insertNode(Codec.string)('n2', 'Node 2'),
+            graph.modifyAtNode(Codec.string)('n3', (n) => `${n} updated`),
+            fp.option.map(graph.nodeEntries(Codec.string))
           ),
           fp.option.none
         );
@@ -135,10 +142,10 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-          graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1'),
-          fp.option.map(graph.entries)
+          graph.insertNode(Codec.string)('n1', 'Node 1'),
+          graph.insertNode(Codec.string)('n2', 'Node 2'),
+          graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1'),
+          fp.option.map(graph.entries(Codec.string))
         ),
         fp.option.some({
           nodes: [
@@ -154,12 +161,12 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
+          graph.insertNode(Codec.string)('n1', 'Node 1'),
+          graph.insertNode(Codec.string)('n2', 'Node 2'),
           fp.option.of,
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')),
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n2', 'n1', 'Edge 2')),
-          fp.option.map(graph.entries)
+          fp.option.chain(graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')),
+          fp.option.chain(graph.insertEdge(Codec.string)('n2', 'n1', 'Edge 2')),
+          fp.option.map(graph.entries(Codec.string))
         ),
         fp.option.some({
           nodes: [
@@ -178,9 +185,9 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-          graph.insertEdge(fp.string.Eq)('n1', 'n1', 'Edge 1'),
-          fp.option.map(graph.entries)
+          graph.insertNode(Codec.string)('n1', 'Node 1'),
+          graph.insertEdge(Codec.string)('n1', 'n1', 'Edge 1'),
+          fp.option.map(graph.entries(Codec.string))
         ),
         fp.option.some({
           nodes: [['n1', 'Node 1']],
@@ -193,9 +200,9 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-          graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1'),
-          fp.option.map(graph.entries)
+          graph.insertNode(Codec.string)('n1', 'Node 1'),
+          graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1'),
+          fp.option.map(graph.entries(Codec.string))
         ),
         fp.option.none
       );
@@ -207,14 +214,14 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, number, string>(),
-          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-          graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
+          graph.insertNode(Codec.string)('n1', 'Node 1'),
+          graph.insertNode(Codec.string)('n2', 'Node 2'),
+          graph.insertNode(Codec.string)('n3', 'Node 3'),
           fp.option.of,
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n1', 'n2', 1)),
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n2', 'n3', 2)),
+          fp.option.chain(graph.insertEdge(Codec.string)('n1', 'n2', 1)),
+          fp.option.chain(graph.insertEdge(Codec.string)('n2', 'n3', 2)),
           fp.option.map(graph.mapEdge((n) => `Edge ${n}`)),
-          fp.option.map(graph.entries)
+          fp.option.map(graph.entries(Codec.string))
         ),
         fp.option.some({
           nodes: [
@@ -236,12 +243,12 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, number>(),
-          graph.insertNode(fp.string.Eq)('n1', 1),
-          graph.insertNode(fp.string.Eq)('n2', 2),
+          graph.insertNode(Codec.string)('n1', 1),
+          graph.insertNode(Codec.string)('n2', 2),
           fp.option.of,
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')),
+          fp.option.chain(graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')),
           fp.option.map(graph.mapNode((n) => `Node ${n}`)),
-          fp.option.map(graph.entries)
+          fp.option.map(graph.entries(Codec.string))
         ),
         fp.option.some({
           nodes: [
@@ -259,11 +266,11 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
+          graph.insertNode(Codec.string)('n1', 'Node 1'),
+          graph.insertNode(Codec.string)('n2', 'Node 2'),
           fp.option.of,
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')),
-          fp.option.map(graph.nodeEntries)
+          fp.option.chain(graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')),
+          fp.option.map(graph.nodeEntries(Codec.string))
         ),
         fp.option.some([
           ['n1', 'Node 1'],
@@ -278,14 +285,14 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-          graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
+          graph.insertNode(Codec.string)('n1', 'Node 1'),
+          graph.insertNode(Codec.string)('n2', 'Node 2'),
+          graph.insertNode(Codec.string)('n3', 'Node 3'),
           fp.option.of,
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')),
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n2', 'n3', 'Edge 2')),
+          fp.option.chain(graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')),
+          fp.option.chain(graph.insertEdge(Codec.string)('n2', 'n3', 'Edge 2')),
           fp.option.map(graph.mapNode((n) => `Node ${n}`)),
-          fp.option.map(graph.edgeEntries)
+          fp.option.map(graph.edgeEntries(Codec.string))
         ),
         fp.option.some([
           [{ from: 'n1', to: 'n2' }, 'Edge 1'],
@@ -300,13 +307,13 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-          graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
+          graph.insertNode(Codec.string)('n1', 'Node 1'),
+          graph.insertNode(Codec.string)('n2', 'Node 2'),
+          graph.insertNode(Codec.string)('n3', 'Node 3'),
           fp.option.of,
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')),
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n2', 'n3', 'Edge 2')),
-          fp.option.map(graph.entries)
+          fp.option.chain(graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')),
+          fp.option.chain(graph.insertEdge(Codec.string)('n2', 'n3', 'Edge 2')),
+          fp.option.map(graph.entries(Codec.string))
         ),
         fp.option.some({
           nodes: [
@@ -328,13 +335,13 @@ describe('index', () => {
       deepStrictEqual(
         fp.function.pipe(
           graph.empty<string, string, string>(),
-          graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-          graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-          graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
+          graph.insertNode(Codec.string)('n1', 'Node 1'),
+          graph.insertNode(Codec.string)('n2', 'Node 2'),
+          graph.insertNode(Codec.string)('n3', 'Node 3'),
           fp.option.of,
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')),
-          fp.option.chain(graph.insertEdge(fp.string.Eq)('n2', 'n3', 'Edge 2')),
-          fp.option.map(graph.toDotFile(fp.function.identity))
+          fp.option.chain(graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')),
+          fp.option.chain(graph.insertEdge(Codec.string)('n2', 'n3', 'Edge 2')),
+          fp.option.map(graph.toDotFile(Codec.string)(fp.function.identity))
         ),
         fp.option.some(`digraph {
 "n1" [label="Node 1"]
@@ -353,17 +360,17 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-            graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.insertNode(Codec.string)('n2', 'Node 2'),
+            graph.insertNode(Codec.string)('n3', 'Node 3'),
             fp.option.of,
             fp.option.chain(
-              graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
+              graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')
             ),
             fp.option.chain(
-              graph.insertEdge(fp.string.Eq)('n2', 'n3', 'Edge 2')
+              graph.insertEdge(Codec.string)('n2', 'n3', 'Edge 2')
             ),
-            fp.option.chain(graph.lookupEdge(fp.string.Eq)('n1', 'n2'))
+            fp.option.chain(graph.lookupEdge(Codec.string)('n1', 'n2'))
           ),
           fp.option.some('Edge 1')
         );
@@ -373,17 +380,17 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.insertNode(fp.string.Eq)('n2', 'Node 2'),
-            graph.insertNode(fp.string.Eq)('n3', 'Node 3'),
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.insertNode(Codec.string)('n2', 'Node 2'),
+            graph.insertNode(Codec.string)('n3', 'Node 3'),
             fp.option.of,
             fp.option.chain(
-              graph.insertEdge(fp.string.Eq)('n1', 'n2', 'Edge 1')
+              graph.insertEdge(Codec.string)('n1', 'n2', 'Edge 1')
             ),
             fp.option.chain(
-              graph.insertEdge(fp.string.Eq)('n2', 'n3', 'Edge 2')
+              graph.insertEdge(Codec.string)('n2', 'n3', 'Edge 2')
             ),
-            fp.option.chain(graph.lookupEdge(fp.string.Eq)('n3', 'n2'))
+            fp.option.chain(graph.lookupEdge(Codec.string)('n3', 'n2'))
           ),
           fp.option.none
         );
@@ -395,8 +402,8 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.lookupNode(fp.string.Eq)('n1')
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.lookupNode(Codec.string)('n1')
           ),
           fp.option.some('Node 1')
         );
@@ -406,8 +413,8 @@ describe('index', () => {
         deepStrictEqual(
           fp.function.pipe(
             graph.empty<string, string, string>(),
-            graph.insertNode(fp.string.Eq)('n1', 'Node 1'),
-            graph.lookupNode(fp.string.Eq)('n2')
+            graph.insertNode(Codec.string)('n1', 'Node 1'),
+            graph.lookupNode(Codec.string)('n2')
           ),
           fp.option.none
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,6 +2543,11 @@ io-ts@^2.2.13:
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.15.tgz#0b0b19a6f8a64f4a524ad5810d56432789428128"
   integrity sha512-ww2ZPrErx5pjCCI/tWRwjlEIDEndnN9kBIxAylXj+WNIH4ZVgaUqFuabGouehkRuvrmvzO5OnZmLf+o50h4izQ==
 
+io-ts@^2.2.16:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.16.tgz#597dffa03db1913fc318c9c6df6931cb4ed808b2"
+  integrity sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,6 +2499,11 @@ iconv-lite@^0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
+immutable@^4.0.0-rc.14:
+  version "4.0.0-rc.14"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.14.tgz#29ba96631ec10867d1348515ac4e6bdba462f071"
+  integrity sha512-pfkvmRKJSoW7JFx0QeYlAmT+kNYvn5j0u7bnpNq4N2RCvHSTlLT208G8jgaquNe+Q8kCPHKOSpxJkyvLDpYq0w==
+
 import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"


### PR DESCRIPTION
Improves overall library performance by changing underlying data structures to [immutable.js Map](https://immutable-js.com/) with arbitrary keys encoded to string using [io-ts](https://gcanti.github.io/io-ts/) [Codec](https://gcanti.github.io/io-ts/modules/Codec.ts.html). See #14 for reasoning behind the change.

Before / after benchmark for 10k operations
```
                        0.2.2 (Map)       0.3.0-dev (immutable.js Map + io-ts)
Insert 10000 nodes        6517 ms               59 ms
Insert 10000 edges       39047 ms               85 ms
Lookup 10000 nodes        1985 ms                8 ms
Lookup 10000 edges        4848 ms               14 ms
```